### PR TITLE
Add conllu: basic sticker Sentence to CoNLL-U conversion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: nix
 nix: 2.2.2
+matrix:
+  include:
+  - env: NIX_CHANNEL=https://nixos.org/channels/nixos-19.09
 env:
   global:
     secure: apQ7Q628bsZkTS0fSk4rd+JvqgVCIA2gw8xxuzb2ZWTybjt9wPrwXstseKmcXAa15LPG9ns9AmsKW/nJFb0ZTWtFSb7Z4CuRRrBxl7osumLhciTFOc5naPbcMc3WXVgFBugzdYeVbCWl1X3t/xmCgfoeKv972kjxpS/a49rzrIxmezhQjKlZzkf+QwRVPJMlwTy6BOXPRki5ubpYTvM0J+w4fJdmDjv8/Tm5FPrYM9yw+jLz7jJaEl3JUtzpV0bZWkyxmVQ2SQnfF3ja1p2uTOqdC90QwO2K2zZlUQ31i6kyKVcYrNFIcRpbh814Fdv7zFX1aSP1dP6fOq4y3xUxsuX1YXtnL878+NC5O78m6+KzQfJcHAzPF7rYN5JlrzEBKmcQQg3nq1VbJAh11qFnrM2ApZHx860inWI4+IjiowsmkxQOvey9qRlwBV2TtHnMg5TtxHflVv5ccBqGEtzpjqteUgFDh+iNrmqMYvsFiafoSR2UEEPDvW7SVHvfIIqef8RBE4UFA8jbBYCtGuFUfqPy/iqBoFEMmLblspAsfrV+NmR4YwnJJojE3uvtUB6AJzRupWW/WIk10wNnZT/d5qZD4HndD1gKd4McEBOFnmKc1bJRV5GGoZtbOSmx04KrBXrqdZD1ZmvKU2ZFVPOeWpYTdUdHYJOIYDd1m90DdiY=
-before_script:
+install:
 - sudo mkdir /etc/nix && echo 'sandbox = true' | sudo tee /etc/nix/nix.conf
 - echo "binary-caches = https://cache.nixos.org https://danieldk-ci.cachix.org" |
   sudo tee -a /etc/nix/nix.conf > /dev/null
@@ -14,7 +17,8 @@ before_script:
 - cachix use danieldk-ci
 - if [ -n "$CACHIX_SIGNING_KEY" ]; then cachix push danieldk-ci --watch-store; fi
   &
+- nix-channel --add "${NIX_CHANNEL}" nixpkgs
+- travis_retry nix-channel --update
 script:
-- nix-build -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/31a6c5a7b507847221598b0d14dd41e935afea4e.tar.gz
-  --expr 'with import <nixpkgs> {}; callPackage ./default.nix { }'
+- nix-build --expr 'with import <nixpkgs> {}; callPackage ./default.nix {}'
 - sleep 10 # Allow cachix to finish

--- a/default.nix
+++ b/default.nix
@@ -8,14 +8,8 @@ let
   sticker = callPackage (fetchFromGitHub {
     owner = "stickeritis";
     repo = "nix-packages";
-    rev = "4a2e5c8ff801d5fb1754054ecf85764b6a7d9c82";
-    sha256 = "1n4i3hgbs1qv2s5gdaw73m46svsp8l3x3s5vl5lxg6h0nd5mpfg1";
-  }) {};
-  sticker-python = callPackage (fetchFromGitHub {
-    owner = "stickeritis";
-    repo = "sticker-python";
-    rev = "98a1820a04cd58ec97edcfcf88b2fc038311511b";
-    sha256 = "01vn2kvmcw1n8945xirccqhr8vmdlq3rlz1wcvkdnrcp06hrl9s9";
+    rev = "2a0192f2ae5b2aff7961c1b90dad5abfb5c827d5";
+    sha256 = "1vsz8hy1dj465g0ng87n5wm2hdjxpw1q62lgjxb8k1rqb1gp3mv9";
   }) {};
 in python3Packages.buildPythonApplication rec {
   pname = "sticker-workbench";
@@ -25,7 +19,7 @@ in python3Packages.buildPythonApplication rec {
 
   propagatedBuildInputs = [
     danieldk.python3Packages.somajo
-    sticker-python
+    sticker.python3Packages.sticker
   ];
 
   checkInputs = with python3Packages; [

--- a/sticker_workbench/conllu.py
+++ b/sticker_workbench/conllu.py
@@ -1,0 +1,66 @@
+def extract_features(token):
+    # Feature iteration is not yet possible in sticker-python,
+    # so probe for specific features.
+    features = []
+    if token.features.contains("NE"):
+        ne = token.features["NE"]
+        if ne != "O":
+            features.append("NameType=%s" % strip_iob(ne))
+
+    if token.features.contains("tf"):
+        features.append("TopoField=%s" % token.features["tf"])
+
+    if len(features) == 0:
+        return "_"
+    else:
+        return "|".join(features)
+
+
+def strip_iob(tag):
+    if tag.startswith("I-"):
+        return tag[2:]
+    if tag.startswith("B-"):
+        return tag[2:]
+
+    return tag
+
+
+def sentences_to_conllu(sentences):
+    """Convert multiple sentences to CoNLL-U"""
+
+    return "\n\n".join(map(lambda s: sentence_to_conllu(s), sentences))
+
+
+def sentence_to_conllu(sentence):
+    """Convert multiple sentences to CoNLL-U"""
+
+    lines = []
+
+    for (idx, token) in enumerate(sentence):
+        if idx == 0:
+            continue
+
+        if token.pos is not None:
+            pos_parts = token.pos.split("-")
+            upos = pos_parts[0]
+            xpos = pos_parts[1]
+        else:
+            xpos = upos = "_"
+
+        if token.head is not None:
+            head = str(token.head)
+        else:
+            head = "_"
+
+        if token.head_rel is not None:
+            head_rel = token.head_rel
+        else:
+            head_rel = "_"
+
+        features = extract_features(token)
+
+        lines.append(
+            "%d\t%s\t_\t%s\t%s\t%s\t%s\t%s\t_\t_" %
+            (idx, token.form, upos, xpos, features, head, head_rel))
+
+    return '\n'.join(lines)

--- a/tests/conllu_test.py
+++ b/tests/conllu_test.py
@@ -1,0 +1,15 @@
+from sticker import Sentence
+from sticker_workbench.conllu import sentence_to_conllu
+
+def test_sentence_to_conll():
+    sent = Sentence(["Hans", "rennt", "heute"], ["DET-DET", "V-VFIN", "ADV-ADV"])
+    sent[1].features["NE"] = "Person"
+    sent[1].features["tf"] = "VF"
+    sent[2].features["tf"] = "LK"
+    sent[3].features["tf"] = "MF"
+
+    # We currently have no way of setting a head/dependent, so
+    # unfortunately we cannot test this yet.
+    assert sentence_to_conllu(sent) == """1	Hans	_	DET	DET	NameType=Person|TopoField=VF	_	_	_	_
+2	rennt	_	V	VFIN	TopoField=LK	_	_	_	_
+3	heute	_	ADV	ADV	TopoField=MF	_	_	_	_"""


### PR DESCRIPTION
Does what is says on the tin. This will probably be removed again in the near-feature, since I am planning to use Brat directly (rather than through `conllu.js`) to be able to visualize named entities more nicely, etc.